### PR TITLE
Feat: Initialize module

### DIFF
--- a/contracts/AMBModule.sol
+++ b/contracts/AMBModule.sol
@@ -41,7 +41,14 @@ contract AMBModule {
     address public owner;
     bytes32 public chainId;
 
-    bool public isInitialized = false;
+    constructor(
+        Executor _executor,
+        IAMB _amb,
+        address _owner,
+        bytes32 _chainId
+    ) {
+        setUp(_executor, _amb, _owner, _chainId);
+    }
 
     /// @param _executor Address of the executor (e.g. a Safe)
     /// @param _amb Address of the AMB contract
@@ -52,13 +59,12 @@ contract AMBModule {
         IAMB _amb,
         address _owner,
         bytes32 _chainId
-    ) external {
-        require(!isInitialized, "Module is already initialized");
+    ) public {
+        require(address(executor) == address(0), "Module is already initialized");
         executor = _executor;
         amb = _amb;
         owner = _owner;
         chainId = _chainId;
-        isInitialized = true;
 
         emit AmbModuleSetup(msg.sender, address(_executor));
     }

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -20,7 +20,9 @@ The first step is to deploy the module. Every Safe will have their own module. T
 
 
 
-A hardhat task can be used to deploy a DAO module instance. This setup task requires the following parameters:
+Hardhat tasks can be used to deploy a DAO module instance. There are two different tasks to deploy the module, the first one is through a normal deployment and passing arguments to the constructor (with the task `setup`), or, deploy the Module through a [Minimal Proxy Factory](https://eips.ethereum.org/EIPS/eip-1167) and save on gas costs (with the task `factory-setup`) - In rinkeby the address of the Proxy Factory is: `0xE9E80739Af9D0DD8AaE6255c96a1266c059469ba` and the singleton of the Bridge Module: `0x399E5e6424DF1448dB19fccFbc9E3DCef95c9f34`.
+
+These setup tasks requires the following parameters:
 - `dao` (the address of the Safe)
 - `amb` (the address of the AMB contract)
 - `owner` (the address of the owner on the other side of the AMB)
@@ -29,9 +31,13 @@ A hardhat task can be used to deploy a DAO module instance. This setup task requ
 An example for this on Rinkeby would be:
 `yarn hardhat --network rinkeby setup --dao <safe_address> --amb  0xD4075FB57fCf038bFc702c915Ef9592534bED5c1 --owner <xDai owner address> --chainid 0x0000000000000000000000000000000000000000000000000000000000000064`
 
+or
+
+`yarn hardhat --network rinkeby factory-setup --factory <factory_address> --singleton <singleton_address> --dao <safe_address> --amb  0xD4075FB57fCf038bFc702c915Ef9592534bED5c1 --owner <side_chain_owner_address> --chainid 0x0000000000000000000000000000000000000000000000000000000000000064`
+
 This should return the address of the deployed SafeBridge module. For this guide we assume this to be `0x4242424242424242424242424242424242424242`
 
-Once the module is deployed you should verify the source code. If you use a network that is Etherscan compatible and you configure the `ETHERSCAN_API_KEY` in your environment you can use the provided hardhat task to do this.
+Once the module is deployed you should verify the source code (Note: If you used the factory deployment the contract should be already verified). If you use a network that is Etherscan compatible and you configure the `ETHERSCAN_API_KEY` in your environment you can use the provided hardhat task to do this.
 
 An example for this on Rinkeby would be:
 `yarn hardhat --network rinkeby verifyEtherscan --module 0x4242424242424242424242424242424242424242 --dao <safe_address> --amb  0xD4075FB57fCf038bFc702c915Ef9592534bED5c1 --owner <xDai owner address> --chainid 0x0000000000000000000000000000000000000000000000000000000000000064`

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -20,7 +20,7 @@ The first step is to deploy the module. Every Safe will have their own module. T
 
 
 
-Hardhat tasks can be used to deploy a DAO module instance. There are two different tasks to deploy the module, the first one is through a normal deployment and passing arguments to the constructor (with the task `setup`), or, deploy the Module through a [Minimal Proxy Factory](https://eips.ethereum.org/EIPS/eip-1167) and save on gas costs (with the task `factory-setup`) - In rinkeby the address of the Proxy Factory is: `0xE9E80739Af9D0DD8AaE6255c96a1266c059469ba` and the Master Copy of the Bridge Module: `0x399E5e6424DF1448dB19fccFbc9E3DCef95c9f34`.
+Hardhat tasks can be used to deploy a DAO module instance. There are two different tasks to deploy the module, the first one is through a normal deployment and passing arguments to the constructor (with the task `setup`), or, deploy the Module through a [Minimal Proxy Factory](https://eips.ethereum.org/EIPS/eip-1167) and save on gas costs (with the task `factory-setup`) - In rinkeby the address of the Proxy Factory is: `0xd067410a85ffC8C55f7245DE4BfE16C95329D232` and the Master Copy of the Bridge Module: `0x399E5e6424DF1448dB19fccFbc9E3DCef95c9f34`.
 
 These setup tasks requires the following parameters:
 - `dao` (the address of the Safe)
@@ -33,7 +33,7 @@ An example for this on Rinkeby would be:
 
 or
 
-`yarn hardhat --network rinkeby factory-setup --factory <factory_address> --masterCopy <masterCopy_address> --dao <safe_address> --amb  0xD4075FB57fCf038bFc702c915Ef9592534bED5c1 --owner <side_chain_owner_address> --chainid 0x0000000000000000000000000000000000000000000000000000000000000064`
+`yarn hardhat --network rinkeby factory-setup --factory <factory_address> --mastercopy <masterCopy_address> --dao <safe_address> --amb  0xD4075FB57fCf038bFc702c915Ef9592534bED5c1 --owner <side_chain_owner_address> --chainid 0x0000000000000000000000000000000000000000000000000000000000000064`
 
 This should return the address of the deployed SafeBridge module. For this guide we assume this to be `0x4242424242424242424242424242424242424242`
 

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -20,7 +20,7 @@ The first step is to deploy the module. Every Safe will have their own module. T
 
 
 
-Hardhat tasks can be used to deploy a DAO module instance. There are two different tasks to deploy the module, the first one is through a normal deployment and passing arguments to the constructor (with the task `setup`), or, deploy the Module through a [Minimal Proxy Factory](https://eips.ethereum.org/EIPS/eip-1167) and save on gas costs (with the task `factory-setup`) - In rinkeby the address of the Proxy Factory is: `0xE9E80739Af9D0DD8AaE6255c96a1266c059469ba` and the singleton of the Bridge Module: `0x399E5e6424DF1448dB19fccFbc9E3DCef95c9f34`.
+Hardhat tasks can be used to deploy a DAO module instance. There are two different tasks to deploy the module, the first one is through a normal deployment and passing arguments to the constructor (with the task `setup`), or, deploy the Module through a [Minimal Proxy Factory](https://eips.ethereum.org/EIPS/eip-1167) and save on gas costs (with the task `factory-setup`) - In rinkeby the address of the Proxy Factory is: `0xE9E80739Af9D0DD8AaE6255c96a1266c059469ba` and the Master Copy of the Bridge Module: `0x399E5e6424DF1448dB19fccFbc9E3DCef95c9f34`.
 
 These setup tasks requires the following parameters:
 - `dao` (the address of the Safe)
@@ -33,7 +33,7 @@ An example for this on Rinkeby would be:
 
 or
 
-`yarn hardhat --network rinkeby factory-setup --factory <factory_address> --singleton <singleton_address> --dao <safe_address> --amb  0xD4075FB57fCf038bFc702c915Ef9592534bED5c1 --owner <side_chain_owner_address> --chainid 0x0000000000000000000000000000000000000000000000000000000000000064`
+`yarn hardhat --network rinkeby factory-setup --factory <factory_address> --masterCopy <masterCopy_address> --dao <safe_address> --amb  0xD4075FB57fCf038bFc702c915Ef9592534bED5c1 --owner <side_chain_owner_address> --chainid 0x0000000000000000000000000000000000000000000000000000000000000064`
 
 This should return the address of the deployed SafeBridge module. For this guide we assume this to be `0x4242424242424242424242424242424242424242`
 
@@ -49,3 +49,7 @@ To allow the SafeBridge module to actually execute transaction it is required to
 ### Executing a transactions
 
 To execute a transaction, call the `requireToPassMessage(address _contract, bytes _data, uint256 _gas)` function on the AMB contract deployed to xDai at [`0xc38D4991c951fE8BCE1a12bEef2046eF36b0FA4A`](https://blockscout.com/poa/xdai/address/0xc38D4991c951fE8BCE1a12bEef2046eF36b0FA4A/contracts) from the `owner` address set in your AMB module.
+
+### Deploy a master copy 
+
+If the contract get an update, you can deploy a new version of a Master Copy using the hardhat task `deployMasterCopy`. An example of the command would be: `yarn hardhat --network rinkeby deployMasterCopy`

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -20,7 +20,7 @@ The first step is to deploy the module. Every Safe will have their own module. T
 
 
 
-Hardhat tasks can be used to deploy a DAO module instance. There are two different tasks to deploy the module, the first one is through a normal deployment and passing arguments to the constructor (with the task `setup`), or, deploy the Module through a [Minimal Proxy Factory](https://eips.ethereum.org/EIPS/eip-1167) and save on gas costs (with the task `factory-setup`) - In rinkeby the address of the Proxy Factory is: `0xd067410a85ffC8C55f7245DE4BfE16C95329D232` and the Master Copy of the Bridge Module: `0x399E5e6424DF1448dB19fccFbc9E3DCef95c9f34`.
+Hardhat tasks can be used to deploy a DAO module instance. There are two different tasks to deploy the module, the first one is through a normal deployment and passing arguments to the constructor (with the task `setup`), or, deploy the Module through a [Minimal Proxy Factory](https://eips.ethereum.org/EIPS/eip-1167) and save on gas costs (with the task `factory-setup`) - In rinkeby the address of the Proxy Factory is: `0xd067410a85ffC8C55f7245DE4BfE16C95329D232` and the Master Copy of the Bridge Module: `0x781c968c88EF6eFCBe13d174b876dc9dc0c3A99b`.
 
 These setup tasks requires the following parameters:
 - `dao` (the address of the Safe)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gnosis/AMBModule",
+  "name": "@gnosis/safe-bridge",
   "version": "1.0.0",
   "description": "An Arbitrary Message Bridge (AMB) module for the Gnosis Safe",
   "directories": {
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@gnosis.pm/mock-contract": "^4.0.0",
+    "@gnosis.pm/safe-contracts": "1.3.0",
     "argv": "^0.0.2",
     "dotenv": "^8.0.0",
     "ethers": "^5.0.19",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "@gnosis.pm/mock-contract": "^4.0.0",
-    "@gnosis.pm/safe-contracts": "1.3.0",
     "argv": "^0.0.2",
     "dotenv": "^8.0.0",
     "ethers": "^5.0.19",

--- a/src/tasks/setup.ts
+++ b/src/tasks/setup.ts
@@ -3,8 +3,8 @@ import "@nomiclabs/hardhat-ethers";
 import { task, types } from "hardhat/config";
 import { Contract } from "ethers";
 
-const FIRST_ADDRESS = "0x0000000000000000000000000000000000000000";
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000001";
+const FIRST_ADDRESS = "0x0000000000000000000000000000000000000001";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const ZERO =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -42,7 +42,7 @@ task("setup", "deploy a SafeBridge Module")
 task("factory-setup", "deploy a SafeBridge Module")
   .addParam("factory", "Address of the Proxy Factory", undefined, types.string)
   .addParam(
-    "masterCopy",
+    "mastercopy",
     "Address of the AMB Module Master Copy",
     undefined,
     types.string
@@ -69,7 +69,7 @@ task("factory-setup", "deploy a SafeBridge Module")
       `function deployModule(
           address masterCopy, 
           bytes memory initializer
-      ) public returns (address clone)`,
+      ) public returns (address proxy)`,
     ];
 
     const Factory = new Contract(taskArgs.factory, FactoryAbi, caller);
@@ -82,7 +82,7 @@ task("factory-setup", "deploy a SafeBridge Module")
     ]);
 
     const receipt = await Factory.deployModule(
-      taskArgs.masterCopy,
+      taskArgs.mastercopy,
       initParams
     ).then((tx: any) => tx.wait(3));
     console.log("Module deployed to:", receipt.logs[1].address);
@@ -127,9 +127,9 @@ task("deployMasterCopy", "deploy a master copy of AMB Module").setAction(
     console.log("Using the account:", caller.address);
     const Module = await hardhatRuntime.ethers.getContractFactory("AMBModule");
     const module = await Module.deploy(
-      ZERO_ADDRESS,
-      ZERO_ADDRESS,
       FIRST_ADDRESS,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
       ZERO
     );
 
@@ -138,7 +138,7 @@ task("deployMasterCopy", "deploy a master copy of AMB Module").setAction(
     console.log("Module deployed to:", module.address);
     await hardhatRuntime.run("verify:verify", {
       address: module.address,
-      constructorArguments: [ZERO_ADDRESS, ZERO_ADDRESS, FIRST_ADDRESS, ZERO],
+      constructorArguments: [FIRST_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS, ZERO],
     });
   }
 );

--- a/src/tasks/setup.ts
+++ b/src/tasks/setup.ts
@@ -1,6 +1,7 @@
 import "hardhat-deploy";
 import "@nomiclabs/hardhat-ethers";
 import { task, types } from "hardhat/config";
+import { Contract } from "ethers";
 
 task("setup", "deploy a SafeBridge Module")
   .addParam("dao", "Address of the DAO (e.g. Safe)", undefined, types.string)
@@ -31,6 +32,47 @@ task("setup", "deploy a SafeBridge Module")
     );
 
     console.log("SafeBridge Module deployed to:", module.address);
+  });
+
+task("factory-setup", "deploy a SafeBridge Module")
+  .addParam("factory", "Address of the Proxy Factory", undefined, types.string)
+  .addParam("singleton", "Address of the Delay Module Master Copy", undefined, types.string)
+  .addParam("dao", "Address of the DAO (e.g. Safe)", undefined, types.string)
+  .addParam("amb", "Address of the AMB", undefined, types.string)
+  .addParam(
+    "owner",
+    "Address of the owner on the other side of the AMB",
+    undefined,
+    types.string
+  )
+  .addParam(
+    "chainid",
+    "Chain ID on the other side of the AMB",
+    undefined,
+    types.string
+  )
+  .setAction(async (taskArgs, hardhatRuntime) => {
+    const [caller] = await hardhatRuntime.ethers.getSigners();
+    console.log("Using the account:", caller.address);
+
+    const FactoryAbi = [
+      `function deployModule(
+          address singleton, 
+          bytes memory initializer
+      ) public returns (address clone)`,
+    ];
+
+    const Factory = new Contract(taskArgs.factory, FactoryAbi, caller)
+    const Module = await hardhatRuntime.ethers.getContractFactory("AMBModule");
+    const initParams = Module.interface.encodeFunctionData('setUp', [
+      taskArgs.dao, 
+      taskArgs.amb,
+      taskArgs.owner,
+      taskArgs.chainid
+    ])
+
+    const receipt = await Factory.deployModule(taskArgs.singleton, initParams).then((tx: any) => tx.wait(3));
+    console.log("Module deployed to:", receipt.logs[1].address);
   });
 
 task("verifyEtherscan", "Verifies the contract on etherscan")

--- a/test/AMBModule.spec.ts
+++ b/test/AMBModule.spec.ts
@@ -1,6 +1,8 @@
 import { expect } from "chai";
-import hre, { deployments, ethers, waffle } from "hardhat";
+import hre, { deployments, waffle } from "hardhat";
 import "@nomiclabs/hardhat-ethers";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 describe("AMBModule", async () => {
   const FORTYTWO =
@@ -43,7 +45,12 @@ describe("AMBModule", async () => {
     const Module = await hre.ethers.getContractFactory("AMBModule");
     const provider = await hre.ethers.getDefaultProvider();
     const network = await provider.getNetwork();
-    const module = await Module.deploy();
+    const module = await Module.deploy(
+      ZERO_ADDRESS,
+      base.amb.address,
+      base.signers[0].address,
+      base.amb.messageSourceChainId()
+    );
     await module.setUp(
       base.executor.address,
       base.amb.address,
@@ -55,6 +62,16 @@ describe("AMBModule", async () => {
   });
 
   const [user1] = waffle.provider.getWallets();
+
+  describe("setUp()", async () => {
+    it("throws if its already initialized", async () => {
+      const Module = await hre.ethers.getContractFactory("AMBModule")
+      const module = await Module.deploy(user1.address, ZERO_ADDRESS, ZERO_ADDRESS, FORTYTWO)
+      await expect(
+          module.setUp(user1.address, ZERO_ADDRESS, ZERO_ADDRESS, FORTYTWO)
+      ).to.be.revertedWith("Module is already initialized")
+    })
+  })
 
   describe("setAmb()", async () => {
     it("throws if not authorized", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -468,11 +468,6 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/mock-contract/-/mock-contract-4.0.0.tgz#eaf500fddcab81b5f6c22280a7b22ff891dd6f87"
   integrity sha512-SkRq2KwPx6vo0LAjSc8JhgQstrQFXRyn2yqquIfub7r2WHi5nUbF8beeSSXsd36hvBcQxQfmOIYNYRpj9JOhrQ==
 
-"@gnosis.pm/safe-contracts@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-contracts/-/safe-contracts-1.3.0.tgz#316741a7690d8751a1f701538cfc9ec80866eedc"
-  integrity sha512-1p+1HwGvxGUVzVkFjNzglwHrLNA67U/axP0Ct85FzzH8yhGJb4t9jDjPYocVMzLorDoWAfKicGy1akPY9jXRVw==
-
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"

--- a/yarn.lock
+++ b/yarn.lock
@@ -468,6 +468,11 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/mock-contract/-/mock-contract-4.0.0.tgz#eaf500fddcab81b5f6c22280a7b22ff891dd6f87"
   integrity sha512-SkRq2KwPx6vo0LAjSc8JhgQstrQFXRyn2yqquIfub7r2WHi5nUbF8beeSSXsd36hvBcQxQfmOIYNYRpj9JOhrQ==
 
+"@gnosis.pm/safe-contracts@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-contracts/-/safe-contracts-1.3.0.tgz#316741a7690d8751a1f701538cfc9ec80866eedc"
+  integrity sha512-1p+1HwGvxGUVzVkFjNzglwHrLNA67U/axP0Ct85FzzH8yhGJb4t9jDjPYocVMzLorDoWAfKicGy1akPY9jXRVw==
+
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"


### PR DESCRIPTION
Changes proposed:

- Make the Safe Bridge Module initializable so we can use a Proxy Factory to deploy and initialize the module.
- Add script to deploy module with factory
- Add script to deploy Master Copy of module

The reasoning of this is that we want to create a Minimal Proxy Factory to deploy different Safe Modules and pay the minor gas possible

We are also allowing the user to deploy the module by themself and pass the parameters through the constructor - This way if the transactions through the proxy get expensive (It costs roughly 5,000 extra gas for each transaction when you use a proxy) the user will be able to use the normal deployment w/constructor