### PR TITLE
Chore: Tests for factory flow added

### DIFF
--- a/contracts/test/TestFactory.sol
+++ b/contracts/test/TestFactory.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.0;
+
+import "@gnosis/zodiac/contracts/factory/ModuleProxyFactory.sol";

--- a/test/AMBModule.spec.ts
+++ b/test/AMBModule.spec.ts
@@ -72,20 +72,6 @@ describe("AMBModule", async () => {
   const [user1] = waffle.provider.getWallets();
 
   describe("setUp()", async () => {
-    it("throws if its already initialized", async () => {
-      await baseSetup();
-      const Module = await hre.ethers.getContractFactory("AMBModule");
-      const module = await Module.deploy(
-        user1.address,
-        user1.address,
-        ZeroAddress,
-        ZeroAddress,
-        FortyTwo
-      );
-      await expect(module.setUp(initializeParams)).to.be.revertedWith(
-        "Module is already initialized"
-      );
-    });
     it("throws if executor is address zero", async () => {
       const { Module } = await setupTestWithTestExecutor();
       await expect(
@@ -97,6 +83,21 @@ describe("AMBModule", async () => {
           FortyTwo
         )
       ).to.be.revertedWith("Executor can not be zero address");
+    });
+
+    it("should emit event because of successful set up", async () => {
+      const Module = await hre.ethers.getContractFactory("AMBModule");
+      const module = await Module.deploy(
+        user1.address,
+        user1.address,
+        user1.address,
+        user1.address,
+        FortyTwo
+      );
+      await module.deployed();
+      await expect(module.deployTransaction)
+        .to.emit(module, "AmbModuleSetup")
+        .withArgs(user1.address, user1.address);
     });
   });
 

--- a/test/FactoryFriendly.spec.ts
+++ b/test/FactoryFriendly.spec.ts
@@ -65,7 +65,6 @@ describe("Module works with factory", () => {
       .then((tx: any) => tx.wait());
 
     // retrieve new address from event
-    console.log(receipt.events)
     const {
       args: [newProxyAddress],
     } = receipt.events.find(

--- a/test/FactoryFriendly.spec.ts
+++ b/test/FactoryFriendly.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from "chai";
+import hre, { deployments, ethers } from "hardhat";
+import "@nomiclabs/hardhat-ethers";
+import { AbiCoder, formatBytes32String } from "ethers/lib/utils";
+
+const FirstAddress = "0x0000000000000000000000000000000000000001";
+const saltNonce = "0xfa";
+
+describe("Module works with factory", () => {
+  const chainId = formatBytes32String("55")
+
+  const paramsTypes = ["address", "address", "address", "address", "bytes32"];
+
+  const baseSetup = deployments.createFixture(async () => {
+    await deployments.fixture();
+    const Factory = await hre.ethers.getContractFactory("ModuleProxyFactory");
+    const AMBModule = await hre.ethers.getContractFactory("AMBModule");
+    const factory = await Factory.deploy();
+
+    const masterCopy = await AMBModule.deploy(
+      FirstAddress,
+      FirstAddress,
+      FirstAddress,
+      FirstAddress,
+      formatBytes32String("0")
+    );
+
+    return { factory, masterCopy };
+  });
+
+  it("should throw because master copy is already initialized", async () => {
+    const { masterCopy } = await baseSetup();
+    const [executor, amb, controller] = await ethers.getSigners();
+
+    const encodedParams = new AbiCoder().encode(paramsTypes, [
+      executor.address,
+      executor.address,
+      amb.address,
+      controller.address,
+      chainId,
+    ]);
+
+    await expect(masterCopy.setUp(encodedParams)).to.be.revertedWith(
+      "Module is already initialized"
+    );
+  });
+
+  it("should deploy new amb module proxy", async () => {
+    const { factory, masterCopy } = await baseSetup();
+    const [executor, amb, controller] = await ethers.getSigners();
+    const paramsValues = [
+      executor.address,
+      executor.address,
+      amb.address,
+      controller.address,
+      chainId,
+    ];
+    const encodedParams = [new AbiCoder().encode(paramsTypes, paramsValues)];
+    const initParams = masterCopy.interface.encodeFunctionData(
+      "setUp",
+      encodedParams
+    );
+    const receipt = await factory
+      .deployModule(masterCopy.address, initParams, saltNonce)
+      .then((tx: any) => tx.wait());
+
+    // retrieve new address from event
+    console.log(receipt.events)
+    const {
+      args: [newProxyAddress],
+    } = receipt.events.find(
+      ({ event }: { event: string }) => event === "ModuleProxyCreation"
+    );
+
+    const newProxy = await hre.ethers.getContractAt(
+      "AMBModule",
+      newProxyAddress
+    );
+    expect(await newProxy.controller()).to.be.eq(controller.address);
+    expect(await newProxy.chainId()).to.be.eq(chainId);
+  });
+});


### PR DESCRIPTION
Changes proposed on this PR:

- Added a new file which is called `FactoryFriendly.spec.sol` and two tests cases has been added:
    1. Make sure that the module is deployed through factory and have the expected params
    2. MasterCopy can not be initialized twice
- Created test contract to import ModuleProxyFactory - Can not import it in the same file as Imports because the Mock contracts are 0.6 and it has a version compatibility with 0.8