### PR TITLE
Feat: Deployment tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ env/
 .env
 .history
 coverage*
+deployments

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -53,4 +53,4 @@ To execute a transaction, call the `requireToPassMessage(address _contract, byte
 
 ### Deploy a master copy 
 
-If the contract get an update, you can deploy a new version of a Master Copy using the hardhat task `deployMasterCopy`. An example of the command would be: `yarn hardhat --network rinkeby deployMasterCopy`
+The master copy contracts can be deployed through `yarn deploy` command. Note that this only should be done if the AMBModule contract gets an update and the ones referred on the (zodiac repository)[https://github.com/gnosis/zodiac/blob/master/src/factory/constants.ts] should be used.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "hardhat compile",
     "test": "hardhat test",
+    "deploy": "hardhat deploy --network",
     "coverage": "hardhat coverage",
     "lint": "yarn lint:sol && yarn lint:ts",
     "lint:sol": "solhint 'contracts/**/*.sol'",

--- a/src/deploy/deploy_module.ts
+++ b/src/deploy/deploy_module.ts
@@ -1,0 +1,29 @@
+import { formatBytes32String } from "ethers/lib/utils";
+import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+const FirstAddress = "0x0000000000000000000000000000000000000001";
+
+const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre;
+  const { deployer } = await getNamedAccounts();
+  const { deploy } = deployments;
+  const chainId = formatBytes32String("0");
+  const args = [
+    FirstAddress,
+    FirstAddress,
+    FirstAddress,
+    FirstAddress,
+    chainId,
+  ];
+
+  await deploy("AMBModule", {
+    from: deployer,
+    args,
+    log: true,
+    deterministicDeployment: true,
+  });
+};
+
+deploy.tags = ["amb-module"];
+export default deploy;

--- a/src/deploy/verify.ts
+++ b/src/deploy/verify.ts
@@ -1,0 +1,32 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { TASK_ETHERSCAN_VERIFY } from "hardhat-deploy";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { run } = hre;
+  if (!["rinkeby", "mainnet"].includes(hre.network.name)) {
+    return;
+  }
+
+  if (!process.env.INFURA_KEY) {
+    console.log(
+      `Could not find Infura key in env, unable to connect to network ${hre.network.name}`
+    );
+    return;
+  }
+
+  console.log("Verification of AMB Module in etherscan...");
+  console.log("Waiting for 1 minute before verifying contracts...");
+  // Etherscan needs some time to process before trying to verify.
+  await new Promise((resolve) => setTimeout(resolve, 60000));
+
+  console.log("Starting to verify now");
+
+  await run(TASK_ETHERSCAN_VERIFY, {
+    apiKey: process.env.ETHERSCAN_KEY_API,
+    license: "GPL-3.0",
+    solcInput: true,
+    forceLicense: true, // we need this because contracts license is LGPL-3.0-only
+  });
+};
+export default func;


### PR DESCRIPTION
Changes proposed on this PR:
- Hardhat deploy is now being used to deploy master copy contracts, and verify them on etherscan
- Removed `deployMasterCopy` task from `src/setup.ts` file
- Documentation updated accordingly