### PR TITLE
Chore: Change of variable name executor to avatar

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,5 +1,5 @@
 module.exports = {
-  skipFiles: ["test/Imports.sol", "test/TestExecutor.sol"],
+  skipFiles: ["test/Imports.sol", "test/TestAvatar.sol"],
   mocha: {
     grep: "@skip-on-coverage", // Find everything with this tag
     invert: true, // Run the grep's inverse set.

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,5 +1,5 @@
 module.exports = {
-  skipFiles: ["test/Imports.sol", "test/TestAvatar.sol"],
+  skipFiles: ["test/Imports.sol", "test/TestAvatar.sol", "test/Mock.sol"],
   mocha: {
     grep: "@skip-on-coverage", // Find everything with this tag
     invert: true, // Run the grep's inverse set.

--- a/contracts/AMBModule.sol
+++ b/contracts/AMBModule.sol
@@ -25,20 +25,20 @@ contract AMBModule is Module {
     bytes32 public chainId;
 
     /// @param _owner Address of the  owner
-    /// @param _executor Address of the executor (e.g. a Safe)
+    /// @param _avatar Address of the avatar (e.g. a Safe)
     /// @param _amb Address of the AMB contract
     /// @param _controller Address of the authorized controller contract on the other side of the bridge
     /// @param _chainId Address of the authorized chainId from which owner can initiate transactions
     constructor(
         address _owner,
-        address _executor,
+        address _avatar,
         IAMB _amb,
         address _controller,
         bytes32 _chainId
     ) {
         bytes memory initParams = abi.encode(
             _owner,
-            _executor,
+            _avatar,
             _amb,
             _controller,
             _chainId
@@ -49,15 +49,15 @@ contract AMBModule is Module {
     function setUp(bytes memory initParams) public override {
         (
             address _owner,
-            address _executor,
+            address _avatar,
             IAMB _amb,
             address _controller,
             bytes32 _chainId
         ) = abi.decode(initParams, (address, address, IAMB, address, bytes32));
         require(!initialized, "Module is already initialized");
         initialized = true;
-        require(_executor != address(0), "Executor can not be zero address");
-        avatar = _executor;
+        require(_avatar != address(0), "Avatar can not be zero address");
+        avatar = _avatar;
         amb = _amb;
         controller = _controller;
         chainId = _chainId;
@@ -65,7 +65,7 @@ contract AMBModule is Module {
         __Ownable_init();
         transferOwnership(_owner);
 
-        emit AmbModuleSetup(msg.sender, _executor);
+        emit AmbModuleSetup(msg.sender, _avatar);
     }
 
     /// @dev Check that the amb, chainId, and owner are valid
@@ -78,7 +78,7 @@ contract AMBModule is Module {
 
     /// @dev Set the AMB contract address
     /// @param _amb Address of the AMB contract
-    /// @notice This can only be called by the executor
+    /// @notice This can only be called by the avatar
     function setAmb(address _amb) public onlyOwner {
         require(address(amb) != _amb, "AMB address already set to this");
         amb = IAMB(_amb);
@@ -86,7 +86,7 @@ contract AMBModule is Module {
 
     /// @dev Set the approved chainId
     /// @param _chainId ID of the approved network
-    /// @notice This can only be called by the executor
+    /// @notice This can only be called by the avatar
     function setChainId(bytes32 _chainId) public onlyOwner {
         require(chainId != _chainId, "chainId already set to this");
         chainId = _chainId;
@@ -94,7 +94,7 @@ contract AMBModule is Module {
 
     /// @dev Set the controller address
     /// @param _controller Set the address of controller on the other side of the bridge
-    /// @notice This can only be called by the executor
+    /// @notice This can only be called by the avatar
     function setController(address _controller) public onlyOwner {
         require(controller != _controller, "controller already set to this");
         controller = _controller;

--- a/contracts/test/TestAvatar.sol
+++ b/contracts/test/TestAvatar.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0;
 
-contract TestExecutor {
+contract TestAvatar {
     address public module;
 
     receive() external payable {}

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -14,7 +14,7 @@ DISCLAIMER: Check the deployed AMB contracts before using them.
 
 ## Setting up the module
 
-The first step is to deploy the module. Every Safe will have their own module. The module is linked to a Safe (called executor in the contract) and an AMB contract. The Safe cannot be changed after deployment.
+The first step is to deploy the module. Every Safe will have their own module. The module is linked to a Safe (called avatar in the contract) and an AMB contract. The Safe cannot be changed after deployment.
 
 ### Deploying the module
 
@@ -24,24 +24,24 @@ Hardhat tasks can be used to deploy an AMB instance. There are two different tas
 
 These setup tasks requires the following parameters:
 - `owner` (the address of the owner)
-- `executor` (the address of the executor)
+- `avatar` (the address of the avatar)
 - `amb` (the address of the AMB contract)
 - `controller` (the address of the controller on the other side of the AMB)
 - `chainId` (the chain ID on the other side of the AMB)
 
 An example for this on Rinkeby would be:
-`yarn hardhat --network rinkeby setup --owner <owner_address> --executor <executor_address> --amb  0xD4075FB57fCf038bFc702c915Ef9592534bED5c1 --controller <xDai controller address> --chainid 0x0000000000000000000000000000000000000000000000000000000000000064`
+`yarn hardhat --network rinkeby setup --owner <owner_address> --avatar <avatar_address> --amb  0xD4075FB57fCf038bFc702c915Ef9592534bED5c1 --controller <xDai controller address> --chainid 0x0000000000000000000000000000000000000000000000000000000000000064`
 
 or
 
-`yarn hardhat --network rinkeby factory-setup --factory <factory_address> --mastercopy <masterCopy_address> --owner <owner_address> --executor <executor_address> --amb  0xD4075FB57fCf038bFc702c915Ef9592534bED5c1 --controller <side_chain_controller_address> --chainid 0x0000000000000000000000000000000000000000000000000000000000000064`
+`yarn hardhat --network rinkeby factory-setup --factory <factory_address> --mastercopy <masterCopy_address> --owner <owner_address> --avatar <avatar_address> --amb  0xD4075FB57fCf038bFc702c915Ef9592534bED5c1 --controller <side_chain_controller_address> --chainid 0x0000000000000000000000000000000000000000000000000000000000000064`
 
 This should return the address of the deployed SafeBridge module. For this guide we assume this to be `0x4242424242424242424242424242424242424242`
 
 Once the module is deployed you should verify the source code (Note: If you used the factory deployment the contract should be already verified). If you use a network that is Etherscan compatible and you configure the `ETHERSCAN_API_KEY` in your environment you can use the provided hardhat task to do this.
 
 An example for this on Rinkeby would be:
-`yarn hardhat --network rinkeby verifyEtherscan --module 0x4242424242424242424242424242424242424242 --owner <owner_address> --executor <executor_address> --amb  0xD4075FB57fCf038bFc702c915Ef9592534bED5c1 --controller <xDai controller address> --chainid 0x0000000000000000000000000000000000000000000000000000000000000064`
+`yarn hardhat --network rinkeby verifyEtherscan --module 0x4242424242424242424242424242424242424242 --owner <owner_address> --avatar <avatar_address> --amb  0xD4075FB57fCf038bFc702c915Ef9592534bED5c1 --controller <xDai controller address> --chainid 0x0000000000000000000000000000000000000000000000000000000000000064`
 
 ### Enabling the module
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@gnosis.pm/mock-contract": "^4.0.0",
+    "@openzeppelin/contracts": "^4.3.1",
     "argv": "^0.0.2",
     "dotenv": "^8.0.0",
     "ethers": "^5.0.19",

--- a/src/tasks/setup.ts
+++ b/src/tasks/setup.ts
@@ -11,7 +11,7 @@ const Zero =
 
 task("setup", "deploy a SafeBridge Module")
   .addParam("owner", "Address of the owner", undefined, types.string)
-  .addParam("executor", "Address of the executor", undefined, types.string)
+  .addParam("avatar", "Address of the avatar", undefined, types.string)
   .addParam("amb", "Address of the AMB", undefined, types.string)
   .addParam(
     "controller",
@@ -31,7 +31,7 @@ task("setup", "deploy a SafeBridge Module")
     const Module = await hardhatRuntime.ethers.getContractFactory("AMBModule");
     const module = await Module.deploy(
       taskArgs.owner,
-      taskArgs.executor,
+      taskArgs.avatar,
       taskArgs.amb,
       taskArgs.controller,
       taskArgs.chainid
@@ -49,7 +49,7 @@ task("factorySetup", "deploy a SafeBridge Module")
     types.string
   )
   .addParam("owner", "Address of the owner", undefined, types.string)
-  .addParam("executor", "Address of the executor", undefined, types.string)
+  .addParam("avatar", "Address of the avatar", undefined, types.string)
   .addParam("amb", "Address of the AMB", undefined, types.string)
   .addParam(
     "controller",
@@ -80,7 +80,7 @@ task("factorySetup", "deploy a SafeBridge Module")
       ["address", "address", "address", "address", "bytes32"],
       [
         taskArgs.owner,
-        taskArgs.executor,
+        taskArgs.avatar,
         taskArgs.amb,
         taskArgs.controller,
         taskArgs.chainid,
@@ -106,8 +106,8 @@ task("verifyEtherscan", "Verifies the contract on etherscan")
   )
   .addParam("owner", "Address of the owner", undefined, types.string)
   .addParam(
-    "executor",
-    "Address of the executor (e.g. Safe)",
+    "avatar",
+    "Address of the avatar (e.g. Safe)",
     undefined,
     types.string
   )
@@ -129,7 +129,7 @@ task("verifyEtherscan", "Verifies the contract on etherscan")
       address: taskArgs.module,
       constructorArgsParams: [
         taskArgs.owner,
-        taskArgs.executor,
+        taskArgs.avatar,
         taskArgs.amb,
         taskArgs.controller,
         taskArgs.chainid,

--- a/test/AMBModule.spec.ts
+++ b/test/AMBModule.spec.ts
@@ -12,8 +12,8 @@ describe("AMBModule", async () => {
 
   const baseSetup = deployments.createFixture(async () => {
     await deployments.fixture();
-    const Executor = await hre.ethers.getContractFactory("TestExecutor");
-    const executor = await Executor.deploy();
+    const Avatar = await hre.ethers.getContractFactory("TestAvatar");
+    const avatar = await Avatar.deploy();
     const Mock = await hre.ethers.getContractFactory("Mock");
     const mock = await Mock.deploy();
     const amb = await hre.ethers.getContractAt("IAMB", mock.address);
@@ -42,30 +42,30 @@ describe("AMBModule", async () => {
     initializeParams = new AbiCoder().encode(
       ["address", "address", "address", "address", "bytes32"],
       [
-        executor.address,
-        executor.address,
+        avatar.address,
+        avatar.address,
         amb.address,
         signers[0].address,
         await amb.messageSourceChainId(),
       ]
     );
 
-    return { Executor, executor, module, mock, badMock, amb, badAmb, signers };
+    return { Avatar, avatar, module, mock, badMock, amb, badAmb, signers };
   });
 
-  const setupTestWithTestExecutor = deployments.createFixture(async () => {
+  const setupTestWithTestAvatar = deployments.createFixture(async () => {
     const base = await baseSetup();
     const Module = await hre.ethers.getContractFactory("AMBModule");
     const provider = await hre.ethers.getDefaultProvider();
     const network = await provider.getNetwork();
     const module = await Module.deploy(
-      base.executor.address,
-      base.executor.address,
+      base.avatar.address,
+      base.avatar.address,
       base.amb.address,
       base.signers[0].address,
       base.amb.messageSourceChainId()
     );
-    await base.executor.setModule(module.address);
+    await base.avatar.setModule(module.address);
     return { ...base, Module, module, network };
   });
 
@@ -86,8 +86,8 @@ describe("AMBModule", async () => {
         "Module is already initialized"
       );
     });
-    it("throws if executor is address zero", async () => {
-      const { Module } = await setupTestWithTestExecutor();
+    it("throws if avatar is address zero", async () => {
+      const { Module } = await setupTestWithTestAvatar();
       await expect(
         Module.deploy(
           ZeroAddress,
@@ -96,20 +96,20 @@ describe("AMBModule", async () => {
           ZeroAddress,
           FortyTwo
         )
-      ).to.be.revertedWith("Executor can not be zero address");
+      ).to.be.revertedWith("Avatar can not be zero address");
     });
   });
 
   describe("setAmb()", async () => {
     it("throws if not authorized", async () => {
-      const { module } = await setupTestWithTestExecutor();
+      const { module } = await setupTestWithTestAvatar();
       await expect(module.setAmb(module.address)).to.be.revertedWith(
         "Ownable: caller is not the owner"
       );
     });
 
     it("throws if already set to input address", async () => {
-      const { module, executor, amb } = await setupTestWithTestExecutor();
+      const { module, avatar, amb } = await setupTestWithTestAvatar();
 
       expect(await module.amb()).to.be.equals(amb.address);
 
@@ -117,19 +117,19 @@ describe("AMBModule", async () => {
         amb.address,
       ]);
       await expect(
-        executor.exec(module.address, 0, calldata)
+        avatar.exec(module.address, 0, calldata)
       ).to.be.revertedWith("AMB address already set to this");
     });
 
     it("updates AMB address", async () => {
-      const { module, executor, amb } = await setupTestWithTestExecutor();
+      const { module, avatar, amb } = await setupTestWithTestAvatar();
 
       expect(await module.amb()).to.be.equals(amb.address);
 
       const calldata = module.interface.encodeFunctionData("setAmb", [
         user1.address,
       ]);
-      executor.exec(module.address, 0, calldata);
+      avatar.exec(module.address, 0, calldata);
 
       expect(await module.amb()).to.be.equals(user1.address);
     });
@@ -137,26 +137,26 @@ describe("AMBModule", async () => {
 
   describe("setChainId()", async () => {
     it("throws if not authorized", async () => {
-      const { module } = await setupTestWithTestExecutor();
+      const { module } = await setupTestWithTestAvatar();
       await expect(module.setChainId(FortyTwo)).to.be.revertedWith(
         "Ownable: caller is not the owner"
       );
     });
 
     it("throws if already set to input address", async () => {
-      const { module, executor, network } = await setupTestWithTestExecutor();
+      const { module, avatar, network } = await setupTestWithTestAvatar();
       const currentChainID = await module.chainId();
 
       const calldata = module.interface.encodeFunctionData("setChainId", [
         currentChainID,
       ]);
       await expect(
-        executor.exec(module.address, 0, calldata)
+        avatar.exec(module.address, 0, calldata)
       ).to.be.revertedWith("chainId already set to this");
     });
 
     it("updates chainId", async () => {
-      const { module, executor, network } = await setupTestWithTestExecutor();
+      const { module, avatar, network } = await setupTestWithTestAvatar();
       let currentChainID = await module.chainId();
       const newChainID = FortyTwo;
       expect(await currentChainID._hex).to.not.equals(newChainID);
@@ -164,7 +164,7 @@ describe("AMBModule", async () => {
       const calldata = module.interface.encodeFunctionData("setChainId", [
         newChainID,
       ]);
-      executor.exec(module.address, 0, calldata);
+      avatar.exec(module.address, 0, calldata);
 
       currentChainID = await module.chainId();
 
@@ -174,26 +174,26 @@ describe("AMBModule", async () => {
 
   describe("setController()", async () => {
     it("throws if not authorized", async () => {
-      const { module, signers } = await setupTestWithTestExecutor();
+      const { module, signers } = await setupTestWithTestAvatar();
       await expect(
         module.connect(signers[3]).setController(user1.address)
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
     it("throws if already set to input address", async () => {
-      const { module, executor } = await setupTestWithTestExecutor();
+      const { module, avatar } = await setupTestWithTestAvatar();
       const currentController = await module.controller();
 
       const calldata = module.interface.encodeFunctionData("setController", [
         currentController,
       ]);
       await expect(
-        executor.exec(module.address, 0, calldata)
+        avatar.exec(module.address, 0, calldata)
       ).to.be.revertedWith("controller already set to this");
     });
 
     it("updates controller", async () => {
-      const { module, executor, signers } = await setupTestWithTestExecutor();
+      const { module, avatar, signers } = await setupTestWithTestAvatar();
       let currentController = await module.owner();
       let newController = signers[1].address;
 
@@ -202,7 +202,7 @@ describe("AMBModule", async () => {
       const calldata = module.interface.encodeFunctionData("setController", [
         newController,
       ]);
-      executor.exec(module.address, 0, calldata);
+      avatar.exec(module.address, 0, calldata);
 
       currentController = await module.controller();
       expect(await module.controller()).to.be.equals(newController);
@@ -211,7 +211,7 @@ describe("AMBModule", async () => {
 
   describe("executeTrasnaction()", async () => {
     it("throws if amb is unauthorized", async () => {
-      const { module } = await setupTestWithTestExecutor();
+      const { module } = await setupTestWithTestAvatar();
       const tx = {
         to: user1.address,
         value: 0,
@@ -224,7 +224,7 @@ describe("AMBModule", async () => {
     });
 
     it("throws if chainId is unauthorized", async () => {
-      const { mock, module, amb } = await setupTestWithTestExecutor();
+      const { mock, module, amb } = await setupTestWithTestAvatar();
       const ambTx = await module.populateTransaction.executeTransaction(
         user1.address,
         0,
@@ -243,7 +243,7 @@ describe("AMBModule", async () => {
     });
 
     it("throws if messageSender is unauthorized", async () => {
-      const { mock, module, signers, amb } = await setupTestWithTestExecutor();
+      const { mock, module, signers, amb } = await setupTestWithTestAvatar();
       const ambTx = await module.populateTransaction.executeTransaction(
         user1.address,
         0,
@@ -262,7 +262,7 @@ describe("AMBModule", async () => {
     });
 
     it("throws if module transaction fails", async () => {
-      const { mock, module } = await setupTestWithTestExecutor();
+      const { mock, module } = await setupTestWithTestAvatar();
       const ambTx = await module.populateTransaction.executeTransaction(
         user1.address,
         10000000,
@@ -277,7 +277,7 @@ describe("AMBModule", async () => {
     });
 
     it("executes a transaction", async () => {
-      const { mock, module, signers } = await setupTestWithTestExecutor();
+      const { mock, module, signers } = await setupTestWithTestAvatar();
 
       const moduleTx = await module.populateTransaction.setController(
         signers[1].address

--- a/test/AMBModule.spec.ts
+++ b/test/AMBModule.spec.ts
@@ -73,7 +73,7 @@ describe("AMBModule", async () => {
 
   describe("setUp()", async () => {
     it("throws if executor is address zero", async () => {
-      const { Module } = await setupTestWithTestExecutor();
+      const { Module } = await setupTestWithTestAvatar();
       await expect(
         Module.deploy(
           ZeroAddress,
@@ -117,9 +117,9 @@ describe("AMBModule", async () => {
       const calldata = module.interface.encodeFunctionData("setAmb", [
         amb.address,
       ]);
-      await expect(
-        avatar.exec(module.address, 0, calldata)
-      ).to.be.revertedWith("AMB address already set to this");
+      await expect(avatar.exec(module.address, 0, calldata)).to.be.revertedWith(
+        "AMB address already set to this"
+      );
     });
 
     it("updates AMB address", async () => {
@@ -151,9 +151,9 @@ describe("AMBModule", async () => {
       const calldata = module.interface.encodeFunctionData("setChainId", [
         currentChainID,
       ]);
-      await expect(
-        avatar.exec(module.address, 0, calldata)
-      ).to.be.revertedWith("chainId already set to this");
+      await expect(avatar.exec(module.address, 0, calldata)).to.be.revertedWith(
+        "chainId already set to this"
+      );
     });
 
     it("updates chainId", async () => {
@@ -188,9 +188,9 @@ describe("AMBModule", async () => {
       const calldata = module.interface.encodeFunctionData("setController", [
         currentController,
       ]);
-      await expect(
-        avatar.exec(module.address, 0, calldata)
-      ).to.be.revertedWith("controller already set to this");
+      await expect(avatar.exec(module.address, 0, calldata)).to.be.revertedWith(
+        "controller already set to this"
+      );
     });
 
     it("updates controller", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,19 +850,19 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "16.7.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.9.tgz#3bf27710839e62a470ddf6bd8dd321f1737ce5b4"
-  integrity sha512-KktxVzS4FPDFVHUUOWyZMvRo//8vqOLITtLMhFSW9IdLsYT/sPyXj3wXtaTcR7A7olCe7R2Xy7R+q5pg2bU46g==
+  version "16.7.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.10.tgz#7aa732cc47341c12a16b7d562f519c2383b6d4fc"
+  integrity sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==
 
 "@types/node@^12.12.6":
-  version "12.20.22"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.22.tgz#732d69f1106de6ab4b64e130ad43d745719683c8"
-  integrity sha512-P87zMpHfn4/8LRmY3jm3b9oWsQ9wMe5Wnx5MuRqE6C832Wqnoz5Agh0/eIQ5WywvdlI+VJU6F92s1dl3ScD5ig==
+  version "12.20.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.23.tgz#d0d5885bb885ee9b1ed114a04ea586540a1b2e2a"
+  integrity sha512-FW0q7NI8UnjbKrJK8NGr6QXY69ATw9IFe6ItIo5yozPwA9DU/xkhiPddctUVyrmFXvyFYerYgQak/qu200UBDw==
 
 "@types/node@^14.14.21":
-  version "14.17.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.13.tgz#392ba5c51b1550ee3c38082cf1e59b3144f06871"
-  integrity sha512-OqG3iSnFg3cnJLsSRyhriILdDfBOwGty0fmnalbsPdYKbDgK6TI9On/36lzO/1bcaeEkg9OGD2wYLjx8t5MZNQ==
+  version "14.17.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.14.tgz#6fda9785b41570eb628bac27be4b602769a3f938"
+  integrity sha512-rsAj2u8Xkqfc332iXV12SqIsjVi07H479bOP4q94NAcjzmAvapumEhuVIt53koEf7JFrpjgNKjBga5Pnn/GL8A==
 
 "@types/pbkdf2@^3.0.0":
   version "3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -511,7 +511,7 @@
 
 "@gnosis/zodiac@github:gnosis/zodiac#master":
   version "0.0.0"
-  resolved "https://codeload.github.com/gnosis/zodiac/tar.gz/37e7aae683e8ed971c27c35f4486e6c7688275f3"
+  resolved "https://codeload.github.com/gnosis/zodiac/tar.gz/30dce26b46150166769bdf55bc2d5ad0eeabe5de"
   dependencies:
     "@gnosis.pm/mock-contract" "^4.0.0"
     "@gnosis.pm/safe-contracts" "1.3.0"
@@ -608,6 +608,11 @@
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.3.1.tgz#d2fdbacd010f9bc2228d58f9d3d3db4e49818ea6"
   integrity sha512-vqS3gb1J5xlKc+7a931a5Qmg3HDR168E6aCfPY6lPrdFZV4TymN2+HVJNCqCo+KP2UMYDtqRsXu+KB/0L0E34g==
+
+"@openzeppelin/contracts@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.1.tgz#c01f791ce6c9d3989ac1a643267501dbe336b9e3"
+  integrity sha512-QjgbPPlmDK2clK1hzjw2ROfY8KA5q+PfhDUUxZFEBCZP9fi6d5FuNoh/Uq0oCTMEKPmue69vhX2jcl0N/tFKGw==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
@@ -767,9 +772,9 @@
     web3 "1.5.2"
 
 "@truffle/provider@^0.2.24":
-  version "0.2.38"
-  resolved "https://registry.yarnpkg.com/@truffle/provider/-/provider-0.2.38.tgz#7a55a9083cdc6b896d40ac0c547ef3acdfcb0d92"
-  integrity sha512-YKdTUST+G741jFtwgwSpXA0sni5ClLPfhLVUirLxKAiLXI3HnYDl1TAtf/THTPWGMmfd3ygfkXVlxceYuSNuRQ==
+  version "0.2.39"
+  resolved "https://registry.yarnpkg.com/@truffle/provider/-/provider-0.2.39.tgz#5a544e734fa5c41c28cacae88e139ed13d5c9ead"
+  integrity sha512-svL1u/BtPyteZbYnngxVBvYHkesTRLFYXdklDJT2S+X4jy8dmHRZIUdM6SL4SOrDPICiEnnp1fczsVWEqrEdig==
   dependencies:
     "@truffle/error" "^0.0.14"
     "@truffle/interface-adapter" "^0.5.5"
@@ -2658,9 +2663,9 @@ copy-descriptor@^0.1.0:
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js-pure@^3.0.1:
-  version "3.16.4"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.16.4.tgz#8b23122628d88c560f209812b9b2d9ebbce5e29c"
-  integrity sha512-bY1K3/1Jy9D8Jd12eoeVahNXHLfHFb4TXWI8SQ4y8bImR9qDPmGITBAfmcffTkgUvbJn87r8dILOTWW5kZzkgA==
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.17.2.tgz#ba6311b6aa1e2f2adeba4ac6ec51a9ff40bdc1af"
+  integrity sha512-2VV7DlIbooyTI7Bh+yzOOWL9tGwLnQKHno7qATE+fqZzDKYr6llVjVQOzpD/QLZFgXDPb8T71pJokHEZHEYJhQ==
 
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.12"
@@ -3041,9 +3046,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.47:
-  version "1.3.825"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.825.tgz#5d361eeaaf591bb2ce06cfeff86354b429d662b8"
-  integrity sha512-BO3FfWVeH8GQ0DBbi4HCL09OPgvN+0goqWlgKOCmCXcnrlgL5GA69nb7ZyjpWgpFUacBftg8BrXU2WLOSuHAxQ==
+  version "1.3.829"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.829.tgz#efd360b594824fcd84e24c6eb0c8e41e2a44fbc7"
+  integrity sha512-5EXDbvsaLRxS1UOfRr8Hymp3dR42bvBNPgzVuPwUFj3v66bpvDUcNwwUywQUQYn/scz26/3Sgd3fNVGQOlVwvQ==
 
 elliptic@6.5.4, elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.3:
   version "6.5.4"
@@ -4283,9 +4288,9 @@ fmix@^0.1.0:
     imul "^1.0.0"
 
 follow-redirects@^1.10.0, follow-redirects@^1.12.1:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.2.tgz#cecb825047c00f5e66b142f90fed4f515dec789b"
-  integrity sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA==
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.3.tgz#6ada78118d8d24caee595595accdc0ac6abd022e"
+  integrity sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==
 
 for-each@^0.3.3, for-each@~0.3.3:
   version "0.3.3"


### PR DESCRIPTION
Changes proposed on this proposal:
- `Executor` name has been changed to `Avatar` in tests, documentation, setup scripts, and contract
- `TestExecutor` file changed to `TestAvatar`