### PR TITLE
Convert chainid from input to correct 32 bytes hex representation

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 2,
+    "semi": true,
+    "singleQuote": false
+  }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -58,14 +58,18 @@ export default {
       ...sharedNetworkConfig,
       url: `https://rinkeby.infura.io/v3/${INFURA_KEY}`,
     },
+    goerli: {
+      ...sharedNetworkConfig,
+      url: `https://goerli.infura.io/v3/${INFURA_KEY}`,
+    },
     xdai: {
       ...sharedNetworkConfig,
       url: "https://xdai.poanetwork.dev",
     },
     matic: {
       ...sharedNetworkConfig,
-      url: "https://rpc-mainnet.maticvigil.com"
-    }
+      url: "https://rpc-mainnet.maticvigil.com",
+    },
   },
   namedAccounts: {
     deployer: 0,

--- a/src/tasks/setup.ts
+++ b/src/tasks/setup.ts
@@ -11,7 +11,7 @@ interface BridgeTaskArgs {
   target: string;
   amb: string;
   controller: string;
-  chainid: string;
+  chainid: number;
   proxied: boolean;
 }
 
@@ -21,7 +21,7 @@ const deployBridgeModule = async (
 ) => {
   const [caller] = await hardhatRuntime.ethers.getSigners();
   console.log("Using the account:", caller.address);
-  const bridgeChainId = formatBytes32String(taskArgs.chainid);
+  const bridgeChainId = intToBytes32HexString(taskArgs.chainid);
 
   if (taskArgs.proxied) {
     const chainId = await hardhatRuntime.getChainId();
@@ -84,7 +84,7 @@ task("setup", "deploy an AMB Module")
     "chainid",
     "Chain ID on the other side of the AMB",
     undefined,
-    types.string
+    types.int
   )
   .addParam(
     "proxied",
@@ -104,6 +104,7 @@ task("verifyEtherscan", "Verifies the contract on etherscan")
     undefined,
     types.string
   )
+  .addParam("target", "Address of the target", undefined, types.string)
   .addParam("amb", "Address of the AMB", undefined, types.string)
   .addParam(
     "controller",
@@ -127,10 +128,16 @@ task("verifyEtherscan", "Verifies the contract on etherscan")
           taskArgs.target,
           taskArgs.amb,
           taskArgs.controller,
-          taskArgs.chainid,
+          intToBytes32HexString(taskArgs.chainid),
         ],
       });
     }
   );
 
 export {};
+
+function intToBytes32HexString(i: number): string {
+  // convert to hex string
+  // pad left with zeros up until 64 -> 32 bytes
+  return `0x${i.toString(16).padStart(64, "0")}`;
+}


### PR DESCRIPTION
The AMB interface contains a chainId function which returns an int256. We actually state bytes32 on the interface we code inline in AMBModule.sol, but the two types are ABI equivalent, so no biggie. Our bridge module checks that request comes from the configured allowed/chainId. Therefor we are incorrectly providing the chainId argument to the bridge constructor:

- We encode the chainId (string that comes from the command line arguments) into a 32 byte buffer. Important here is that it's encoded as a string, i.e., the actual utf8 chars
- This fix converts: input string -> integer -> hex string representation for the int -> pads left with zeros until length 64. The result is the hex representation in bytes of a uint256