### PR TITLE
feat: introduce lisk sepolia

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -112,6 +112,12 @@ export default {
       ...sharedNetworkConfig,
       url: `https://api.avax.network/ext/bc/C/rpc`,
     },
+    "lisk-sepolia": {
+      ...sharedNetworkConfig,
+      chainId: 4202,
+      url: "https://rpc.sepolia-api.lisk.com",
+      gasPrice: 1000000000,
+    },
   },
   namedAccounts: {
     deployer: 0,
@@ -121,5 +127,15 @@ export default {
   },
   etherscan: {
     apiKey: ETHERSCAN_API_KEY,
+    customChains: [
+      {
+        network: "lisk-sepolia",
+        chainId: 4202,
+        urls: {
+          apiURL: "https://sepolia-blockscout.lisk.com/api",
+          browserURL: "https://sepolia-blockscout.lisk.com",
+        },
+      },
+    ],
   },
 };


### PR DESCRIPTION
## **Description:**

This PR adds support for the **Lisk Sepolia** testnet in Hardhat configuration. The newly introduced network allows deploying and verifying smart contracts on Lisk's Sepolia blockchain.

### Changes:
- Added `lisk-sepolia` network configuration to `hardhat.config.ts`.
- Included `lisk-sepolia` under the `etherscan.apiKey` configuration using a placeholder key.
- Extended `customChains` configuration to support contract verification for Lisk Sepolia.

### Deployment and Verification:
The following contracts were successfully deployed on **Lisk Sepolia**:
- 🚀 AMBModule@1.0.0: Successfully verified at https://sepolia-blockscout.lisk.com/address/0x03B5eBD2CB2e3339E93774A1Eb7c8634B8C393A9

### References:
- Official Lisk documentation: [Deploying Smart Contracts with Hardhat](https://docs.lisk.com/building-on-lisk/deploying-smart-contract/with-Hardhat)
